### PR TITLE
Add styles for missing form classes

### DIFF
--- a/style.css
+++ b/style.css
@@ -309,3 +309,80 @@ body {
     width: 100%;
   }
 }
+
+/* ─────────────────────────────────────────────────────────────
+   12) Additional plugin utility classes
+───────────────────────────────────────────────────────────── */
+#fbuilder .cp_avoid_hidden,
+#fbuilder .top_aligned,
+#fbuilder .cp_v_v {
+  display: block;
+}
+
+#fbuilder .pb0 {
+  padding-bottom: 0 !important;
+}
+
+#fbuilder .pbreak {
+  margin-bottom: 24px;
+}
+
+#fbuilder .fields {
+  margin-bottom: 20px;
+}
+
+#fbuilder .fieldCalendarService {
+  margin-bottom: 20px;
+}
+
+#fbuilder .ahbfield_service,
+#fbuilder .ahbfield_quantity {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #E2E8F0;
+  border-radius: 6px;
+  background: #fff;
+  color: #0F172A;
+}
+
+#fbuilder .ahbfield_quantity_div {
+  margin-top: 10px;
+}
+
+#fbuilder .ahbfield_quantity_label {
+  display: block;
+  font-size: 14px;
+  margin-bottom: 4px;
+  color: #0F172A;
+}
+
+#fbuilder .availableslot {
+  margin-bottom: 12px;
+}
+
+#fbuilder .usedSlots {
+  margin-top: 16px;
+}
+
+#fbuilder .clearer {
+  clear: both;
+}
+
+#fbuilder .medium {
+  width: 260px;
+}
+
+#fbuilder .small {
+  width: 120px;
+}
+
+#fbuilder .required::after {
+  content: "*";
+  color: #dc2626;
+  margin-left: 4px;
+}
+
+#fbuilder .captcha {
+  margin-top: 16px;
+}
+


### PR DESCRIPTION
## Summary
- support additional plugin utility classes for the booking form

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68424b00474c832b9f3a975c608c057e