### PR TITLE
Improve table and form layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -52,11 +52,22 @@ body {
 #fbuilder .ui-datepicker {
   background: #fff !important;
   border-radius: 16px;
-  box-shadow: 0 4px 8px rgba(0,0,0,.08);
+  box-shadow: none !important;
   color: #0F172A;
   padding: 32px !important;
   width: 100% !important;
   box-sizing: border-box;
+}
+#fbuilder .ui-datepicker-inline {
+  max-width: none !important;
+}
+
+#fbuilder .ui-datepicker table,
+#fbuilder .ui-datepicker thead,
+#fbuilder .ui-datepicker tr,
+#fbuilder .ui-datepicker th,
+#fbuilder .ui-datepicker td {
+  border: 0 !important;
 }
 
 /* ─────────────────────────────────────────────────────────────
@@ -309,3 +320,89 @@ body {
     width: 100%;
   }
 }
+
+/* ─────────────────────────────────────────────────────────────
+   12) Table cleanup and formfields container
+───────────────────────────────────────────────────────────── */
+#fbuilder .formfields,
+.formfields {
+  margin: 0 auto !important;
+  padding: 0 !important;
+  width: 100% !important;
+  box-sizing: border-box;
+  background: #F8FAFC;
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.formfields > * {
+  margin: 0;
+  padding: 0;
+}
+
+#fbuilder .formfields table,
+.formfields table {
+  width: auto !important;
+  margin: 0 auto;
+  border-collapse: collapse;
+  border-spacing: 0;
+  table-layout: fixed;
+}
+
+#fbuilder .formfields th,
+#fbuilder .formfields td,
+.formfields th,
+.formfields td {
+  padding: 2px 4px;
+  border: 1px solid #E2E8F0;
+  text-align: left;
+}
+
+.formfields th {
+  background: #F8FAFC;
+  font-weight: 600;
+}
+
+.formfields input,
+.formfields select,
+.formfields textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.formfields label {
+  display: block;
+  margin-bottom: 4px;
+  font-weight: 600;
+}
+
+.formfields button,
+.formfields input[type="submit"],
+.formfields input[type="button"] {
+  padding: 6px 12px;
+  background: #3182CE;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+@media (max-width: 720px) {
+  .formfields {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────
+   13) AHB field service special layout
+───────────────────────────────────────────────────────────── */
+#ahbfield_service {
+  display: block !important;
+  width: 100% !important;
+  flex-basis: 100% !important;
+  margin: 8px 0 !important;
+}
+


### PR DESCRIPTION
## Summary
- refine `.formfields` container to center content and share a background
- tables and forms align horizontally on desktop and stack on mobile
- reduce padding inside table cells
- force `#ahbfield_service` to occupy its own line regardless of layout
- remove calendar shadow and borders around internal table elements

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68424899c868832b918e05368acb0c7a