### PR TITLE
Fix CSS style cleanup

### DIFF
--- a/style.css
+++ b/style.css
@@ -338,11 +338,7 @@ body {
 }
 
 .formfields > * {
-  margin: 0;
-  padding: 0;
 
-=======
-=======
   margin: 0 !important;
   padding: 0 !important;
   width: 100% !important;
@@ -353,13 +349,6 @@ body {
 #fbuilder .formfields table,
 .formfields table {
 
-  width: auto !important;
-  margin: 0 auto;
-=======
-
-  width: auto !important;
-  margin: 0 auto;
-=======
   width: 100% !important;
   margin: 0;
 
@@ -372,15 +361,7 @@ body {
 #fbuilder .formfields td,
 .formfields th,
 .formfields td {
-
-  padding: 2px 4px;
-=======
-
-  padding: 2px 4px;
-=======
   padding: 4px 8px;
-
-
   border: 1px solid #E2E8F0;
   text-align: left;
 }
@@ -415,7 +396,6 @@ body {
 }
 
 
-=======
 
 
 @media (max-width: 720px) {
@@ -436,9 +416,6 @@ body {
   margin: 8px 0 !important;
 }
 
-=======
-=======
-=======
    12) Additional plugin utility classes
 ───────────────────────────────────────────────────────────── */
 #fbuilder .cp_avoid_hidden,
@@ -463,7 +440,15 @@ body {
   margin-bottom: 20px;
 }
 
-#fbuilder .ahbfield_service,
+#fbuilder .ahbfield_service {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #E2E8F0;
+  border-radius: 6px;
+  background: #fff;
+  color: #0F172A;
+}
+
 #fbuilder .ahbfield_quantity {
   width: 100%;
   padding: 8px;
@@ -512,6 +497,4 @@ body {
 
 #fbuilder .captcha {
   margin-top: 16px;
-
 }
-


### PR DESCRIPTION
## Summary
- remove leftover conflict markers and duplicate rules in `style.css`
- split `.ahbfield_service` selector into its own CSS block

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684344a04af0832bb563e2d5f8d4e5d4