### PR TITLE
Make calendar and slots full width

### DIFF
--- a/style.css
+++ b/style.css
@@ -37,6 +37,10 @@ body {
   overflow-y: auto;
   max-height: 560px;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 
 /* ─────────────────────────────────────────────────────────────
@@ -60,6 +64,7 @@ body {
 }
 #fbuilder .ui-datepicker-inline {
   max-width: none !important;
+  width: 100% !important;
 }
 
 #fbuilder .ui-datepicker table,
@@ -180,12 +185,15 @@ body {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-gap: 24px 32px;
+  width: 100%;
+  justify-items: center;
+  margin: 0 auto;
 }
 #fbuilder .slots div a {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 140px;
+  width: 100%;
   height: 48px;
   border-radius: 8px;
   background: #F8FAFC;
@@ -285,6 +293,7 @@ body {
   #fbuilder .slotsCalendar,
   #fbuilder .profileColumn {
     max-width: 100% !important;
+    width: 100% !important;
     flex: none !important;
     margin-bottom: 20px;
   }
@@ -438,6 +447,7 @@ body {
 
 #fbuilder .fieldCalendarService {
   margin-bottom: 20px;
+  width: 100%;
 }
 
 #fbuilder .ahbfield_service {


### PR DESCRIPTION
## Summary
- center slot grid items horizontally and ensure they fill their container

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843467a22ec832b84636104f744464d